### PR TITLE
Update math.h

### DIFF
--- a/src/base/math.h
+++ b/src/base/math.h
@@ -19,14 +19,14 @@ inline float sign(float f)
 {
 	return f<0.0f?-1.0f:1.0f;
 }
-
+/*
 inline int round(float f)
 {
 	if(f > 0)
 		return (int)(f+0.5f);
 	return (int)(f-0.5f);
 }
-
+*/
 template<typename T, typename TB>
 inline T mix(const T a, const T b, TB amount)
 {


### PR DESCRIPTION
`round()` 函数由 stdlib 定义了，这边重新定义会报错，不应该被自定义。
The `round()` is defined by the stdlib and then should not be customized.